### PR TITLE
Fixes Broken Github link on Website

### DIFF
--- a/_layout/nav.html
+++ b/_layout/nav.html
@@ -27,7 +27,7 @@
                 <a class="nav-link" href="/research">Research</a>
             </li>
             <li class="nav-item">
-                <a class="nav-link" href="#">GitHub</a>
+                <a class="nav-link" href="https://github.com/QuantumBFS/Yao.jl">GitHub</a>
             </li>
         </ul>
     </div>


### PR DESCRIPTION
There is Github Link that was broken on website. It was referring back the same website instead of Github repo. 
All the details are given in QuantumBFS/Yao.jl#347. 
I fixed by replacing it with correct link. 
Kindly let me know if there is any suggestios for this PR. 
Thank you